### PR TITLE
Support Unity 6 and add new features

### DIFF
--- a/Assets/Settings/SampleSceneProfile.asset
+++ b/Assets/Settings/SampleSceneProfile.asset
@@ -368,6 +368,21 @@ MonoBehaviour:
   multiScattering:
     m_OverrideState: 0
     m_Value: 0.5
+  shadows:
+    m_OverrideState: 0
+    m_Value: 0
+  shadowResolution:
+    m_OverrideState: 0
+    m_Value: 256
+  shadowDistance:
+    m_OverrideState: 0
+    m_Value: 8000
+  shadowOpacity:
+    m_OverrideState: 1
+    m_Value: 0.75
+  shadowOpacityFallback:
+    m_OverrideState: 0
+    m_Value: 0
   temporalAccumulationFactor:
     m_OverrideState: 0
     m_Value: 0.95

--- a/Assets/Settings/URP-HighFidelity-Renderer.asset
+++ b/Assets/Settings/URP-HighFidelity-Renderer.asset
@@ -115,4 +115,6 @@ MonoBehaviour:
   upscaleMode: 0
   preferredRenderMode: 1
   ambientProbe: 1
+  sunAttenuation: 0
   resetOnStart: 1
+  outputDepth: 0

--- a/Assets/VolumetricClouds/VolumetricClouds.mat
+++ b/Assets/VolumetricClouds/VolumetricClouds.mat
@@ -120,6 +120,7 @@ Material:
     - _BumpScale: 1
     - _ClearCoatMask: 0
     - _ClearCoatSmoothness: 0
+    - _CloudNearPlane: 1199.7988
     - _Cull: 2
     - _Cutoff: 0.5
     - _DensityMultiplier: 0.19971202
@@ -172,7 +173,7 @@ Material:
     - _SunSize: 0.04
     - _SunSizeConvergence: 5
     - _Surface: 0
-    - _VerticalErosionWindDisplacement: -190.3615
+    - _VerticalErosionWindDisplacement: -28.32639
     - _VerticalShapeNoiseOffset: 0
     - _VerticalShapeWindDisplacement: 0
     - _WorkflowMode: 1

--- a/Assets/VolumetricClouds/VolumetricCloudsDefs.hlsl
+++ b/Assets/VolumetricClouds/VolumetricCloudsDefs.hlsl
@@ -35,6 +35,7 @@ half _SunLightDimmer;
 float _EarthRadius;
 half _AccumulationFactor;
 half _NormalizationFactor;
+half _CloudNearPlane;
 CBUFFER_END
 
 #endif

--- a/Assets/VolumetricClouds/VolumetricCloudsShadows.hlsl
+++ b/Assets/VolumetricClouds/VolumetricCloudsShadows.hlsl
@@ -1,0 +1,158 @@
+#ifndef URP_VOLUMETRIC_CLOUDS_SHADOWS_HLSL
+#define URP_VOLUMETRIC_CLOUDS_SHADOWS_HLSL
+
+// avoid the cloud horizontal scrolling when in camera space
+#define _LOCAL_VOLUMETRIC_CLOUDS
+
+#include "./VolumetricCloudsDefs.hlsl"
+#include "./VolumetricCloudsUtilities.hlsl"
+
+TEXTURE2D(_VolumetricCloudsShadow);
+
+half _ShadowCookieResolution;
+float3 _CloudShadowSunOrigin;
+float3 _VolumetricCloudsShadowOriginToggle;
+float3 _CloudShadowSunRight;
+float3 _CloudShadowSunUp;
+half3 _CloudShadowSunForward;
+half _ShadowIntensity;
+half _ShadowOpacityFallback;
+float3 _CameraPositionPS;
+//half _ShadowPlaneOffset;
+
+half3 TraceVolumetricCloudsShadows(Varyings input) : SV_Target
+{
+    // Compute the normalized coordinate on the shadow plane
+    float2 normalizedCoord = input.texcoord;
+
+    // Compute the origin of the ray properties in the planet space
+    float3 rayOriginPS = _CloudShadowSunOrigin.xyz + (normalizedCoord.x * _CloudShadowSunRight.xyz + normalizedCoord.y * _CloudShadowSunUp.xyz);
+    half3 rayDirection = _CloudShadowSunForward.xyz;
+
+    // Compute the attenuation
+    half transmittance = 1.0;
+    float closestDistance = FLT_MAX;
+    float farthestDistance = 0.0;
+    bool validShadow = false;
+
+    // Intersect the outer sphere
+    float radialDistance = length(rayOriginPS);
+    float cosChi = dot(rayOriginPS, rayDirection) * rcp(radialDistance);
+    float2 tInner = IntersectSphere(_LowestCloudAltitude, cosChi, radialDistance);
+    float2 tOuter = IntersectSphere(_HighestCloudAltitude, cosChi, radialDistance);
+    if (tInner.y >= 0.0 && tOuter.y >= 0.0)
+    {
+        // Compute the integration range
+        float startDistance = tInner.y;
+        float totalDistance = tOuter.y - tInner.y;
+
+        float stepSize = totalDistance / 16;
+
+        for (int i = 1; i < 16; ++i)
+        {
+            // Compute the sphere intersection position
+            float dist = (startDistance + stepSize * i);
+            float3 positionPS = rayOriginPS + rayDirection * dist;
+
+            // Get the coverage at intersection point
+            CloudCoverageData cloudCoverageData;
+            GetCloudCoverageData(positionPS, cloudCoverageData);
+
+            // Compute the cloud density
+            CloudProperties cloudProperties;
+            EvaluateCloudProperties(positionPS, 0.0, 0.0, true, true, cloudProperties);
+
+            // Apply the camera fade it to match the clouds perceived by the camera
+            cloudProperties.density *= DensityFadeValue(length(positionPS - _CameraPositionPS.xyz));
+
+            if (cloudProperties.density > CLOUD_DENSITY_TRESHOLD)
+            {
+                // Apply the extinction
+                closestDistance = min(closestDistance, startDistance + stepSize * (i - 1));
+                farthestDistance = max(farthestDistance, startDistance + stepSize * i);
+                const half3 currentStepExtinction = exp(-_ScatteringTint.xyz * cloudProperties.density * cloudProperties.sigmaT * stepSize);
+                transmittance *= Luminance(currentStepExtinction);
+                validShadow = true;
+            }
+        }
+    }
+    // If we didn't manage to hit a non null density, we need to fix the distances
+    //half4 result = validShadow ? half4(1.0 / closestDistance, lerp(1.0 - _ShadowIntensity, 1.0, transmittance), 1.0 / farthestDistance, 1.0) : half4(0.0, 1.0, 0.0, 0.0);
+    
+    half shadows = lerp(1.0 - _ShadowIntensity, 1.0, transmittance);
+
+    /*
+    // Evaluate the shadow
+    float2 distances = validShadow ? float2(1.0 / closestDistance, 1.0 / farthestDistance) : float2(0.0, 0.0);
+
+    // This should be the world position of the shading point in object's shader.
+    // We use a user defined shadow receiving plane here.
+    float3 positionWS = float3(_VolumetricCloudsShadowOriginToggle.x, _ShadowPlaneOffset, _VolumetricCloudsShadowOriginToggle.z);
+
+    // Compute the vector from the shadow origin to the point to shade
+    float3 shadowOriginVec = positionWS - _VolumetricCloudsShadowOriginToggle.xyz;
+    //float zCoord = dot(shadowOriginVec, _CloudShadowSunForward.xyz);
+    float zCoord = _ShadowPlaneOffset - _VolumetricCloudsShadowOriginToggle.y;
+
+    half shadowRange = saturate((1.0 / zCoord - distances.x) / (distances.y - distances.x));
+    shadows = shadows != 1.0 ? lerp(shadows, 1.0, shadowRange) : 1.0;
+    */
+
+    half3 result = validShadow ? shadows.xxx : half3(1.0, 1.0, 1.0);
+
+    return result;
+}
+
+half gaussian(half radius, half sigma)
+{
+    half v = radius / sigma;
+    return exp(-v * v);
+}
+
+half3 FilterVolumetricCloudsShadow(Varyings input) : SV_Target
+{
+    float2 normalizedCoord = input.texcoord;
+
+    // We let the sampler handle clamping to border.
+    if (normalizedCoord.x <= _BlitTexture_TexelSize.x || normalizedCoord.y <= _BlitTexture_TexelSize.y || normalizedCoord.x >= 1.0 - _BlitTexture_TexelSize.x || normalizedCoord.y >= 1.0 - _BlitTexture_TexelSize.y)
+        return _ShadowOpacityFallback.xxx;
+
+    // Loop through the neighborhood
+    half3 shadowSum = 0.0;
+    half3 weightSum = 0.0;
+    for (int y = -1; y <= 1; ++y)
+    {
+        for (int x = -1; x <= 1; ++x)
+        {
+            half r = sqrt(x * x + y * y);
+            half weight = gaussian(r, 0.9);
+
+            // Read the shadow data from the texture
+            float2 offsetUV = normalizedCoord + float2(x, y) * _BlitTexture_TexelSize.xy;
+            half3 shadowData = SAMPLE_TEXTURE2D_LOD(_BlitTexture, s_linear_clamp_sampler, offsetUV, 0).xyz;
+
+            // here, we only take into account shadow distance data if transmission is not 1.0
+            /*if (shadowData.y != 1.0)
+            {
+                shadowSum.xz += weight * shadowData.xz;
+                weightSum.xz += weight;
+            }
+            */
+            shadowSum.xyz += weight * shadowData.xyz;
+            weightSum.xyz += weight;
+        }
+    }
+    /*
+    if (any(weightSum.xz == 0.0))
+    {
+        half3 shadowData = SAMPLE_TEXTURE2D_LOD(_BlitTexture, s_linear_clamp_sampler, normalizedCoord, 0).xyz;
+        shadowSum = shadowData;
+        weightSum = 1.0;
+    }
+    */
+
+    // Normalize and return the result
+    return shadowSum / weightSum;
+}
+
+#endif

--- a/Assets/VolumetricClouds/VolumetricCloudsShadows.hlsl.meta
+++ b/Assets/VolumetricClouds/VolumetricCloudsShadows.hlsl.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a3338de06403bd94f94b6a093f453f71
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VolumetricClouds/VolumetricCloudsURP.cs
+++ b/Assets/VolumetricClouds/VolumetricCloudsURP.cs
@@ -2,12 +2,19 @@ using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.Universal;
 using UnityEngine.Experimental.Rendering;
+using Unity.Mathematics;
+using static Unity.Mathematics.math;
+
+#if UNITY_6000_0_OR_NEWER
+using UnityEngine.Rendering.RenderGraphModule;
+#endif
 
 /// <summary>
 /// A renderer feature that adds volumetric clouds support to the URP volume.
 /// </summary>
 [DisallowMultipleRendererFeature("Volumetric Clouds URP")]
 [Tooltip("Add this Renderer Feature to support volumetric clouds in URP Volume.")]
+[HelpURL("https://github.com/jiaozi158/UnityVolumetricCloudsURP/tree/main")]
 public class VolumetricCloudsURP : ScriptableRendererFeature
 {
     [Header("Setup")]
@@ -19,7 +26,7 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
     [Header("Performance")]
     [Tooltip("Specifies if URP renders volumetric clouds in both real-time and baked reflection probes. \nVolumetric clouds in real-time reflection probes may reduce performace.")]
     [SerializeField] private bool reflectionProbe = false;
-    [Range(0.4f, 1.0f), Tooltip("The resolution scale for volumetric clouds rendering.")]
+    [Range(0.25f, 1.0f), Tooltip("The resolution scale for volumetric clouds rendering.")]
     [SerializeField] private float resolutionScale = 0.5f;
     [Tooltip("Select the method to use for upscaling volumetric clouds.")]
     [SerializeField] private CloudsUpscaleMode upscaleMode = CloudsUpscaleMode.Bilinear;
@@ -29,17 +36,25 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
     [Header("Lighting")]
     [Tooltip("Specifies the volumetric clouds ambient probe update frequency.")]
     [SerializeField] private CloudsAmbientMode ambientProbe = CloudsAmbientMode.Dynamic;
+    [Tooltip("Specifies if URP calculates physically based sun attenuation for volumetric clouds.")]
+    [SerializeField] private bool sunAttenuation = false;
 
     [Header("Wind")]
     [Tooltip("Enable to reset the wind offsets to their initial states when start playing.")]
     [SerializeField] private bool resetOnStart = true;
 
+    [Header("Depth")]
+    [Tooltip("Specifies if URP outputs volumetric clouds average depth to a global shader texture named \"_VolumetricCloudsDepthTexture\".")]
+    [SerializeField] private bool outputDepth = false;
+
     private const string shaderName = "Hidden/Sky/VolumetricClouds";
     private VolumetricCloudsPass volumetricCloudsPass;
     private VolumetricCloudsAmbientPass volumetricCloudsAmbientPass;
-    
-    // Pirnt message only once when using the rendering debugger.
+    private VolumetricCloudsShadowsPass volumetricCloudsShadowsPass;
+
+    // Pirnt message only once.
     private bool isLogPrinted = false;
+    private bool isCookiePrinted = false;
 
     /// <summary>
     /// Gets or sets the material of volumetric clouds shader.
@@ -72,12 +87,12 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
     /// Gets or sets the resolution scale for volumetric clouds rendering.
     /// </summary>
     /// <value>
-    /// The resolution scale for volumetric clouds rendering, ranging from 0.4 to 1.0.
+    /// The resolution scale for volumetric clouds rendering, ranging from 0.25 to 1.0.
     /// </value>
     public float ResolutionScale
     {
         get { return resolutionScale; }
-        set { resolutionScale = Mathf.Clamp(value, 0.4f, 1.0f); }
+        set { resolutionScale = Mathf.Clamp(value, 0.25f, 1.0f); }
     }
 
     /// <summary>
@@ -131,6 +146,30 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
         set { resetOnStart = value; }
     }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether URP calculates physically based sun attenuation for volumetric clouds.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if URP calculates physically based sun attenuation for volumetric clouds; otherwise, <c>false</c>.
+    /// </value>
+    public bool SunAttenuation
+    {
+        get { return sunAttenuation; }
+        set { sunAttenuation = value; }
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether URP outputs volumetric clouds average depth to a global shader texture named "_VolumetricCloudsDepthTexture".
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if URP outputs volumetric clouds average depth; otherwise, <c>false</c>.
+    /// </value>
+    public bool OutputCloudsDepth
+    {
+        get { return outputDepth; }
+        set { outputDepth = value; }
+    }
+
     public enum CloudsRenderMode
     {
         [Tooltip("Always use Blit() to copy render textures.")]
@@ -165,14 +204,18 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
         {
             if (material.shader != Shader.Find(shaderName))
             {
+            #if UNITY_EDITOR || DEBUG
                 Debug.LogErrorFormat("Volumetric Clouds URP: Material shader is not {0}.", shaderName);
+            #endif
                 return;
             }
         }
         // No material applied.
         else
         {
-            //Debug.LogError("Volumetric Clouds URP: Material is empty.");
+        #if UNITY_EDITOR || DEBUG
+            Debug.LogError("Volumetric Clouds URP: Material is empty.");
+        #endif
             return;
         }
 
@@ -194,9 +237,11 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
             volumetricCloudsAmbientPass = new(material);
             volumetricCloudsAmbientPass.renderPassEvent = RenderPassEvent.BeforeRendering;
         }
-        else
+
+        if (volumetricCloudsShadowsPass == null)
         {
-            // Update every frame to support runtime changes to these properties.
+            volumetricCloudsShadowsPass = new(material);
+            volumetricCloudsShadowsPass.renderPassEvent = RenderPassEvent.BeforeRendering;
         }
     }
 
@@ -206,13 +251,17 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
             volumetricCloudsPass.Dispose();
         if (volumetricCloudsAmbientPass != null)
             volumetricCloudsAmbientPass.Dispose();
+        if (volumetricCloudsShadowsPass != null)
+            volumetricCloudsShadowsPass.Dispose();
     }
 
     public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
     {
         if (material == null)
         {
+        #if UNITY_EDITOR || DEBUG
             Debug.LogErrorFormat("Volumetric Clouds URP: Material is empty.");
+        #endif
             return;
         }
 
@@ -230,18 +279,43 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
             volumetricCloudsPass.dynamicAmbientProbe = dynamicAmbientProbe;
             volumetricCloudsPass.renderMode = preferredRenderMode;
             volumetricCloudsPass.resetWindOnStart = resetOnStart;
+            volumetricCloudsPass.outputDepth = outputDepth;
+            volumetricCloudsPass.sunAttenuation = sunAttenuation;
+
+            volumetricCloudsShadowsPass.cloudsVolume = cloudsVolume;
+
+            renderer.EnqueuePass(volumetricCloudsPass);
+
+            if (cloudsVolume.shadows.value)
+            {
+                // Check if URP supports "Light Cookies"
+                UniversalRenderPipelineAsset asset = UniversalRenderPipeline.asset;
+                if (asset.supportsLightCookies)
+                {
+                    isCookiePrinted = false;
+                    renderer.EnqueuePass(volumetricCloudsShadowsPass);
+                }
+            #if UNITY_EDITOR || DEBUG
+                else
+                {
+                    // URP may have stripped light cookie varients (in build), so skip the shadow cookie rendering
+                    if (!isCookiePrinted) { Debug.LogWarning("Volumetric Clouds URP: Light Cookies are disabled in the active URP asset. The volumetric clouds shadows will not be rendered."); isCookiePrinted = true; }
+                }
+            #endif
+            }
 
             // No need to render dynamic ambient probe for reflection probes.
-            renderer.EnqueuePass(volumetricCloudsPass);
             if (dynamicAmbientProbe && !isProbeCamera) { renderer.EnqueuePass(volumetricCloudsAmbientPass); }
 
             isLogPrinted = false;
         }
+    #if UNITY_EDITOR || DEBUG
         else if (isDebugger && !renderingDebugger && !isLogPrinted)
         {
             Debug.Log("Volumetric Clouds URP: Disable effect to avoid affecting rendering debugging.");
             isLogPrinted = true;
         }
+    #endif
     }
 
     public class VolumetricCloudsPass : ScriptableRenderPass
@@ -252,16 +326,24 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
         public CloudsUpscaleMode upscaleMode;
         public bool dynamicAmbientProbe;
         public bool resetWindOnStart;
+        public bool outputDepth;
+        public bool sunAttenuation;
 
         private bool denoiseClouds;
 
-        private RTHandle cloudsHandle;
+        private readonly RenderTargetIdentifier[] cloudsHandles = new RenderTargetIdentifier[2];
+
+        private RTHandle cloudsColorHandle;
+        private RTHandle cloudsDepthHandle;
         private RTHandle accumulateHandle;
         private RTHandle historyHandle;
 
         private readonly Material cloudsMaterial;
+
         private readonly bool fastCopy = (SystemInfo.copyTextureSupport & CopyTextureSupport.Basic) != 0;
-        
+
+        private const string profilerTag = "Volumetric Clouds";
+
         private static readonly int numPrimarySteps = Shader.PropertyToID("_NumPrimarySteps");
         private static readonly int numLightSteps = Shader.PropertyToID("_NumLightSteps");
         private static readonly int maxStepSize = Shader.PropertyToID("_MaxStepSize");
@@ -295,18 +377,34 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
         private static readonly int accumulationFactor = Shader.PropertyToID("_AccumulationFactor");
         //private static readonly int normalizationFactor = Shader.PropertyToID("_NormalizationFactor");
         private static readonly int cloudsCurveLut = Shader.PropertyToID("_CloudCurveTexture");
+        private static readonly int cloudnearPlane = Shader.PropertyToID("_CloudNearPlane");
 
-        private static readonly string localClouds = "_LOCAL_VOLUMETRIC_CLOUDS";
-        private static readonly string microErosion = "_CLOUDS_MICRO_EROSION";
-        private static readonly string lowResClouds = "_LOW_RESOLUTION_CLOUDS";
-        private static readonly string cloudsAmbientProbe = "_CLOUDS_AMBIENT_PROBE";
+        private static readonly int cameraDepthTexture = Shader.PropertyToID(_CameraDepthTexture);
+        private static readonly int volumetricCloudsColorTexture = Shader.PropertyToID(_VolumetricCloudsColorTexture);
+        private static readonly int volumetricCloudsHistoryTexture = Shader.PropertyToID(_VolumetricCloudsHistoryTexture);
+        private static readonly int volumetricCloudsDepthTexture = Shader.PropertyToID(_VolumetricCloudsDepthTexture);
+        private static readonly int volumetricCloudsLightingTexture = Shader.PropertyToID(_VolumetricCloudsLightingTexture); // Same as "_VolumetricCloudsColorTexture"
+
+        private const string localClouds = "_LOCAL_VOLUMETRIC_CLOUDS";
+        private const string microErosion = "_CLOUDS_MICRO_EROSION";
+        private const string lowResClouds = "_LOW_RESOLUTION_CLOUDS";
+        private const string cloudsAmbientProbe = "_CLOUDS_AMBIENT_PROBE";
+        private const string outputCloudsDepth = "_OUTPUT_CLOUDS_DEPTH";
+        private const string physicallyBasedSun = "_PHYSICALLY_BASED_SUN";
+
+        private const string _CameraDepthTexture = "_CameraDepthTexture";
+        private const string _VolumetricCloudsColorTexture = "_VolumetricCloudsColorTexture";
+        private const string _VolumetricCloudsHistoryTexture = "_VolumetricCloudsHistoryTexture";
+        private const string _VolumetricCloudsAccumulationTexture = "_VolumetricCloudsAccumulationTexture";
+        private const string _VolumetricCloudsDepthTexture = "_VolumetricCloudsDepthTexture";
+        private const string _VolumetricCloudsLightingTexture = "_VolumetricCloudsLightingTexture"; // Same as "_VolumetricCloudsColorTexture"
 
         private Texture2D customLutPresetMap;
         private readonly Color32[] customLutColorArray = new Color32[customLutMapResolution];
 
-        private const float earthRad = 6378100.0f;
-        private const float windNormalizationFactor = 100000.0f; // NOISE_TEXTURE_NORMALIZATION_FACTOR in "VolumetricCloudsUtilities.hlsl"
-        private const int customLutMapResolution = 64;
+        public const float earthRad = 6378100.0f;
+        public const float windNormalizationFactor = 100000.0f; // NOISE_TEXTURE_NORMALIZATION_FACTOR in "VolumetricCloudsUtilities.hlsl"
+        public const int customLutMapResolution = 64;
 
         // Wind offsets
         private bool prevIsPlaying;
@@ -314,6 +412,8 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
         private float verticalShapeOffset = 0.0f;
         private float verticalErosionOffset = 0.0f;
         private Vector2 windVector = Vector2.zero;
+
+        private static float square(float x) => x * x;
 
         private void UpdateMaterialProperties(Camera camera)
         {
@@ -328,6 +428,12 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
 
             if (dynamicAmbientProbe) { cloudsMaterial.EnableKeyword(cloudsAmbientProbe); }
             else { cloudsMaterial.DisableKeyword(cloudsAmbientProbe); }
+
+            if (outputDepth) { cloudsMaterial.EnableKeyword(outputCloudsDepth); }
+            else { cloudsMaterial.DisableKeyword(outputCloudsDepth); }
+
+            if (sunAttenuation) { cloudsMaterial.EnableKeyword(physicallyBasedSun); }
+            else { cloudsMaterial.DisableKeyword(physicallyBasedSun); }
 
             cloudsMaterial.SetFloat(numPrimarySteps, cloudsVolume.numPrimarySteps.value);
             cloudsMaterial.SetFloat(numLightSteps, cloudsVolume.numLightSteps.value);
@@ -408,10 +514,12 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
             cloudsMaterial.SetFloat(sunLightDimmer, cloudsVolume.sunLightDimmer.value);
             cloudsMaterial.SetFloat(earthRadius, actualEarthRad);
             cloudsMaterial.SetFloat(accumulationFactor, cloudsVolume.temporalAccumulationFactor.value);
+            Vector3 cameraPosPS = camera.transform.position - new Vector3(0.0f, -actualEarthRad, 0.0f);
+            cloudsMaterial.SetFloat(cloudnearPlane, max(GetCloudNearPlane(cameraPosPS, bottomAltitude, highestAltitude), camera.nearClipPlane));
 
             // Custom cloud map is not supported yet.
             //float lowerCloudRadius = (bottomAltitude + highestAltitude) * 0.5f - actualEarthRad;
-            //cloudsMaterial.SetFloat(normalizationFactor, Mathf.Sqrt((6378100.0f + lowerCloudRadius) * (6378100.0f + lowerCloudRadius) - 6378100.0f * actualEarthRad));
+            //cloudsMaterial.SetFloat(normalizationFactor, Mathf.Sqrt((earthRad + lowerCloudRadius) * (earthRad + lowerCloudRadius) - earthRad * actualEarthRad));
 
             PrepareCustomLutData(cloudsVolume);
         }
@@ -444,10 +552,11 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
             var densityCurve = clouds.densityCurve.value;
             var erosionCurve = clouds.erosionCurve.value;
             var ambientOcclusionCurve = clouds.ambientOcclusionCurve.value;
+            Color32 white = Color.white;
             if (densityCurve == null || densityCurve.length == 0)
             {
                 for (int i = 0; i < customLutMapResolution; i++)
-                    pixels[i] = Color.white;
+                    pixels[i] = white;
             }
             else
             {
@@ -469,19 +578,60 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
             cloudsMaterial.SetTexture(cloudsCurveLut, customLutPresetMap);
         }
 
+        private static Vector2 IntersectSphere(float sphereRadius, float cosChi,
+                                          float radialDistance, float rcpRadialDistance)
+        {
+            // r_o = float2(0, r)
+            // r_d = float2(sinChi, cosChi)
+            // p_s = r_o + t * r_d
+            //
+            // R^2 = dot(r_o + t * r_d, r_o + t * r_d)
+            // R^2 = ((r_o + t * r_d).x)^2 + ((r_o + t * r_d).y)^2
+            // R^2 = t^2 + 2 * dot(r_o, r_d) + dot(r_o, r_o)
+            //
+            // t^2 + 2 * dot(r_o, r_d) + dot(r_o, r_o) - R^2 = 0
+            //
+            // Solve: t^2 + (2 * b) * t + c = 0, where
+            // b = r * cosChi,
+            // c = r^2 - R^2.
+            //
+            // t = (-2 * b + sqrt((2 * b)^2 - 4 * c)) / 2
+            // t = -b + sqrt(b^2 - c)
+            // t = -b + sqrt((r * cosChi)^2 - (r^2 - R^2))
+            // t = -b + r * sqrt((cosChi)^2 - 1 + (R/r)^2)
+            // t = -b + r * sqrt(d)
+            // t = r * (-cosChi + sqrt(d))
+            //
+            // Why do we do this? Because it is more numerically robust.
+
+            float d = square(sphereRadius * rcpRadialDistance) - saturate(1 - cosChi * cosChi);
+
+            // Return the value of 'd' for debugging purposes.
+            return (d < 0.0f) ? new Vector2(-1.0f, -1.0f) : (radialDistance * new Vector2(-cosChi - sqrt(d),
+                                                          -cosChi + sqrt(d)));
+        }
+
+        private static float GetCloudNearPlane(Vector3 originPS, float lowerBoundPS, float higherBoundPS)
+        {
+            float radialDistance = length(originPS);
+            float rcpRadialDistance = rcp(radialDistance);
+            float cosChi = 1.0f;
+            Vector2 tInner = IntersectSphere(lowerBoundPS, cosChi, radialDistance, rcpRadialDistance);
+            Vector2 tOuter = IntersectSphere(higherBoundPS, -cosChi, radialDistance, rcpRadialDistance);
+
+            if (tInner.x < 0.0f && tInner.y >= 0.0f) // Below the lower bound
+                return tInner.y;
+            else // Inside or above the cloud volume
+                return max(tOuter.x, 0.0f);
+        }
+
         public VolumetricCloudsPass(Material material, float resolution)
         {
             cloudsMaterial = material;
             resolutionScale = resolution;
         }
 
-        public void Dispose()
-        {
-            cloudsHandle?.Release();
-            historyHandle?.Release();
-            accumulateHandle?.Release();
-        }
-
+        #region Non Render Graph Pass
         public override void OnCameraSetup(CommandBuffer cmd, ref RenderingData renderingData)
         {
             RenderTextureDescriptor desc = renderingData.cameraData.cameraTargetDescriptor;
@@ -489,91 +639,278 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
             desc.msaaSamples = 1;
             desc.useMipMap = false;
             desc.depthBufferBits = 0;
-            RenderingUtils.ReAllocateIfNeeded(ref historyHandle, desc, FilterMode.Point, TextureWrapMode.Clamp, name: "_VolumetricCloudsHistoryTexture"); // lighting.rgb only
+        #if UNITY_6000_0_OR_NEWER
+            RenderingUtils.ReAllocateHandleIfNeeded(ref historyHandle, desc, FilterMode.Point, TextureWrapMode.Clamp, name: _VolumetricCloudsHistoryTexture); // lighting.rgb only
+        #else
+            RenderingUtils.ReAllocateIfNeeded(ref historyHandle, desc, FilterMode.Point, TextureWrapMode.Clamp, name: _VolumetricCloudsHistoryTexture); // lighting.rgb only
+        #endif
 
             desc.colorFormat = RenderTextureFormat.ARGBHalf; // lighting.rgb + transmittance.a
-            RenderingUtils.ReAllocateIfNeeded(ref accumulateHandle, desc, FilterMode.Point, TextureWrapMode.Clamp, name: "_VolumetricCloudsAccumulationTexture");
+        #if UNITY_6000_0_OR_NEWER
+            RenderingUtils.ReAllocateHandleIfNeeded(ref accumulateHandle, desc, FilterMode.Point, TextureWrapMode.Clamp, name: _VolumetricCloudsAccumulationTexture);
+        #else
+            RenderingUtils.ReAllocateIfNeeded(ref accumulateHandle, desc, FilterMode.Point, TextureWrapMode.Clamp, name: _VolumetricCloudsAccumulationTexture);
+        #endif
             
             desc.width = (int)(desc.width * resolutionScale);
             desc.height = (int)(desc.height * resolutionScale);
-            RenderingUtils.ReAllocateIfNeeded(ref cloudsHandle, desc, FilterMode.Bilinear, TextureWrapMode.Clamp, name: "_VolumetricCloudsColorTexture");
+        #if UNITY_6000_0_OR_NEWER
+            RenderingUtils.ReAllocateHandleIfNeeded(ref cloudsColorHandle, desc, FilterMode.Bilinear, TextureWrapMode.Clamp, name: _VolumetricCloudsLightingTexture);
+        #else
+            RenderingUtils.ReAllocateIfNeeded(ref cloudsColorHandle, desc, FilterMode.Bilinear, TextureWrapMode.Clamp, name: _VolumetricCloudsLightingTexture);
+        #endif
 
-            cmd.SetGlobalTexture("_VolumetricCloudsColorTexture", cloudsHandle);
-            cmd.SetGlobalTexture("_VolumetricCloudsHistoryTexture", historyHandle);
+            desc.colorFormat = RenderTextureFormat.RFloat; // average z-depth
+        #if UNITY_6000_0_OR_NEWER
+            RenderingUtils.ReAllocateHandleIfNeeded(ref cloudsDepthHandle, desc, FilterMode.Point, TextureWrapMode.Clamp, name: _VolumetricCloudsDepthTexture);
+        #else
+            RenderingUtils.ReAllocateIfNeeded(ref cloudsDepthHandle, desc, FilterMode.Point, TextureWrapMode.Clamp, name: _VolumetricCloudsDepthTexture);
+        #endif
+
+            cmd.SetGlobalTexture(volumetricCloudsColorTexture, cloudsColorHandle);
+            cmd.SetGlobalTexture(volumetricCloudsLightingTexture, cloudsColorHandle); // Same as "_VolumetricCloudsColorTexture"
+            cmd.SetGlobalTexture(volumetricCloudsDepthTexture, cloudsDepthHandle);
+
+            cloudsMaterial.SetTexture(volumetricCloudsHistoryTexture, historyHandle);
 
             ConfigureInput(ScriptableRenderPassInput.Depth);
-            ConfigureTarget(cloudsHandle, cloudsHandle);
-        }
-
-        public override void FrameCleanup(CommandBuffer cmd)
-        {
-            if (cloudsHandle != null)
-                cmd.ReleaseTemporaryRT(Shader.PropertyToID(cloudsHandle.name));
-            if (historyHandle != null)
-                cmd.ReleaseTemporaryRT(Shader.PropertyToID(historyHandle.name));
-            if (accumulateHandle != null)
-                cmd.ReleaseTemporaryRT(Shader.PropertyToID(accumulateHandle.name));
-        }
-
-        public override void OnCameraCleanup(CommandBuffer cmd)
-        {
-            cloudsHandle = null;
-            historyHandle = null;
-            accumulateHandle = null;
+            ConfigureTarget(cloudsColorHandle, cloudsColorHandle);
         }
 
         public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
         {
             UpdateClouds(renderingData.cameraData.camera);
 
-            RTHandle colorHandle = renderingData.cameraData.renderer.cameraColorTargetHandle;
+            RTHandle cameraColorHandle = renderingData.cameraData.renderer.cameraColorTargetHandle;
 
             CommandBuffer cmd = CommandBufferPool.Get();
-            using (new ProfilingScope(cmd, new ProfilingSampler("Volumetric Clouds")))
+            using (new ProfilingScope(cmd, new ProfilingSampler(profilerTag)))
             {
                 // Clouds Rendering
-                Blitter.BlitCameraTexture(cmd, cloudsHandle, cloudsHandle, cloudsMaterial, pass: 0);
+                if (outputDepth)
+                {
+                    cloudsHandles[0] = cloudsColorHandle;
+                    cloudsHandles[1] = cloudsDepthHandle;
+
+                    // RT-1: clouds lighting
+                    // RT-2: clouds depth
+                    cmd.SetRenderTarget(cloudsHandles, cloudsDepthHandle);
+                    Blitter.BlitTexture(cmd, cameraColorHandle, new Vector4(1.0f, 1.0f, 0.0f, 0.0f), cloudsMaterial, pass: 0);
+                }
+                else
+                {
+                    Blitter.BlitCameraTexture(cmd, cloudsColorHandle, cloudsColorHandle, cloudsMaterial, pass: 0);
+                }
 
                 // Clouds Upscale & Combine
-                Blitter.BlitCameraTexture(cmd, colorHandle, colorHandle, cloudsMaterial, pass: 1);
+                Blitter.BlitCameraTexture(cmd, cameraColorHandle, cameraColorHandle, cloudsMaterial, pass: 1);
+                
+                if (denoiseClouds)
+                {
+                    // Prepare Temporal Reprojection (copy source buffer: colorHandle.rgb + cloudsColorHandle.a)
+                    Blitter.BlitCameraTexture(cmd, cameraColorHandle, accumulateHandle, cloudsMaterial, pass: 2);
 
-                // Prepare Temporal Reprojection (copy source buffer: colorHandle.rgb + cloudsHandle.a)
-                if (denoiseClouds) { Blitter.BlitCameraTexture(cmd, colorHandle, accumulateHandle, cloudsMaterial, pass: 2); }
+                    // Temporal Reprojection
+                    Blitter.BlitCameraTexture(cmd, accumulateHandle, cameraColorHandle, cloudsMaterial, pass: 3);
 
-                // Temporal Reprojection
-                if (denoiseClouds) { Blitter.BlitCameraTexture(cmd, accumulateHandle, colorHandle, cloudsMaterial, pass: 3); }
-
-                // Update history texture for temporal reprojection
-                bool canCopy = colorHandle.rt.format == historyHandle.rt.format && colorHandle.rt.antiAliasing == 1 && fastCopy;
-                if (canCopy && denoiseClouds && renderMode == CloudsRenderMode.CopyTexture) { cmd.CopyTexture(colorHandle, historyHandle); }
-                else if (denoiseClouds) { Blitter.BlitCameraTexture(cmd, colorHandle, historyHandle, RenderBufferLoadAction.Load, RenderBufferStoreAction.Store, cloudsMaterial, pass: 2); }
+                    // Update history texture for temporal reprojection
+                    bool canCopy = cameraColorHandle.rt.format == historyHandle.rt.format && cameraColorHandle.rt.antiAliasing == 1 && fastCopy;
+                    if (canCopy && renderMode == CloudsRenderMode.CopyTexture) { cmd.CopyTexture(cameraColorHandle, historyHandle); }
+                    else { Blitter.BlitCameraTexture(cmd, cameraColorHandle, historyHandle, RenderBufferLoadAction.Load, RenderBufferStoreAction.Store, cloudsMaterial, pass: 2); }
+                }
             }
             context.ExecuteCommandBuffer(cmd);
             cmd.Clear();
             CommandBufferPool.Release(cmd);
         }
+        #endregion
+
+    #if UNITY_6000_0_OR_NEWER
+        #region Render Graph Pass
+        // This class stores the data needed by the pass, passed as parameter to the delegate function that executes the pass
+        private class PassData
+        {
+            internal Material cloudsMaterial;
+
+            internal CloudsUpscaleMode upscaleMode;
+
+            internal float resolutionScale;
+
+            internal bool canCopy;
+            internal bool denoiseClouds;
+            internal bool dynamicAmbientProbe;
+            internal bool outputDepth;
+
+            internal RenderTargetIdentifier[] cloudsHandles;
+
+            internal TextureHandle cameraColorHandle;
+            internal TextureHandle cameraDepthHandle;
+            internal TextureHandle cloudsColorHandle;
+            internal TextureHandle cloudsDepthHandle;
+            internal TextureHandle accumulateHandle;
+            internal TextureHandle historyHandle;
+        }
+
+        // This static method is used to execute the pass and passed as the RenderFunc delegate to the RenderGraph render pass
+        static void ExecutePass(PassData data, UnsafeGraphContext context)
+        {
+            CommandBuffer cmd = CommandBufferHelpers.GetNativeCommandBuffer(context.cmd);
+
+            data.cloudsMaterial.SetTexture(cameraDepthTexture, data.cameraDepthHandle);
+
+            // Clouds Rendering
+            if (data.outputDepth)
+            {
+                data.cloudsHandles[0] = data.cloudsColorHandle;
+                data.cloudsHandles[1] = data.cloudsDepthHandle;
+
+                // RT-1: clouds lighting
+                // RT-2: clouds depth
+                context.cmd.SetRenderTarget(data.cloudsHandles, data.cloudsDepthHandle);
+                Blitter.BlitTexture(cmd, data.cameraColorHandle, new Vector4(1.0f, 1.0f, 0.0f, 0.0f), data.cloudsMaterial, pass: 0);
+            }
+            else
+            {
+                Blitter.BlitCameraTexture(cmd, data.cameraColorHandle, data.cloudsColorHandle, data.cloudsMaterial, pass: 0);
+            }
+
+            // Clouds Upscale & Combine
+            Blitter.BlitCameraTexture(cmd, data.cloudsColorHandle, data.cameraColorHandle, data.cloudsMaterial, pass: 1);
+
+            if (data.denoiseClouds)
+            {
+                // Prepare Temporal Reprojection (copy source buffer: colorHandle.rgb + cloudsHandle.a)
+                Blitter.BlitCameraTexture(cmd, data.cameraColorHandle, data.accumulateHandle, data.cloudsMaterial, pass: 2);
+
+                // Temporal Reprojection
+                Blitter.BlitCameraTexture(cmd, data.accumulateHandle, data.cameraColorHandle, data.cloudsMaterial, pass: 3);
+
+                // Update history texture for temporal reprojection
+                if (data.canCopy)
+                    cmd.CopyTexture(data.cameraColorHandle, data.historyHandle);
+                else
+                    Blitter.BlitCameraTexture(cmd, data.cameraColorHandle, data.historyHandle, RenderBufferLoadAction.Load, RenderBufferStoreAction.Store, data.cloudsMaterial, pass: 2);
+
+                data.cloudsMaterial.SetTexture(volumetricCloudsHistoryTexture, data.historyHandle);
+            }
+        }
+
+        // This is where the renderGraph handle can be accessed.
+        // Each ScriptableRenderPass can use the RenderGraph handle to add multiple render passes to the render graph
+        public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
+        {
+            // add a raster render pass to the render graph, specifying the name and the data type that will be passed to the ExecutePass function
+            using (var builder = renderGraph.AddUnsafePass<PassData>(profilerTag, out var passData))
+            {
+                // UniversalResourceData contains all the texture handles used by the renderer, including the active color and depth textures
+                // The active color and depth textures are the main color and depth buffers that the camera renders into
+                UniversalResourceData resourceData = frameData.Get<UniversalResourceData>();
+                UniversalCameraData cameraData = frameData.Get<UniversalCameraData>();
+
+                UpdateClouds(cameraData.camera);
+
+                // Get the active color texture through the frame data, and set it as the source texture for the blit
+                passData.cameraColorHandle = resourceData.activeColorTexture;
+                passData.cameraDepthHandle = resourceData.cameraDepthTexture;
+
+                RenderTextureFormat cloudsHandleFormat = RenderTextureFormat.ARGBHalf; // lighting.rgb + transmittance.a
+                RenderTextureFormat cloudsDepthHandleFormat = RenderTextureFormat.RFloat; // average z-depth
+
+                RenderTextureDescriptor desc = cameraData.cameraTargetDescriptor;
+
+                desc.msaaSamples = 1;
+                desc.useMipMap = false;
+                desc.depthBufferBits = 0;
+                desc.colorFormat = cloudsHandleFormat;
+
+                TextureHandle accumulateHandle = UniversalRenderer.CreateRenderGraphTexture(renderGraph, desc, name: _VolumetricCloudsAccumulationTexture, false, FilterMode.Point, TextureWrapMode.Clamp);
+                TextureHandle historyHandle = UniversalRenderer.CreateRenderGraphTexture(renderGraph, desc, name: _VolumetricCloudsHistoryTexture, false, FilterMode.Point, TextureWrapMode.Clamp);
+
+                desc.width = (int)(desc.width * resolutionScale);
+                desc.height = (int)(desc.height * resolutionScale);
+                RenderingUtils.ReAllocateHandleIfNeeded(ref cloudsColorHandle, desc, FilterMode.Bilinear, TextureWrapMode.Clamp, name: _VolumetricCloudsLightingTexture);
+                TextureHandle cloudsTextureHandle = renderGraph.ImportTexture(cloudsColorHandle);
+
+                builder.SetGlobalTextureAfterPass(cloudsTextureHandle, volumetricCloudsColorTexture);
+                builder.SetGlobalTextureAfterPass(cloudsTextureHandle, volumetricCloudsLightingTexture); // Same as "_VolumetricCloudsColorTexture"
+
+                if (outputDepth)
+                {
+                    desc.colorFormat = cloudsDepthHandleFormat;
+
+                    TextureHandle cloudsDepthHandle = UniversalRenderer.CreateRenderGraphTexture(renderGraph, desc, name: _VolumetricCloudsDepthTexture, false, FilterMode.Point, TextureWrapMode.Clamp);
+                    passData.cloudsDepthHandle = cloudsDepthHandle;
+                    builder.UseTexture(passData.cloudsDepthHandle, AccessFlags.Write); // change to "AccessFlags.ReadWrite" if you need to access it in opaque object's shader
+                    builder.SetGlobalTextureAfterPass(cloudsDepthHandle, volumetricCloudsDepthTexture);
+                }
+
+                // Fill up the passData with the data needed by the pass
+                passData.cloudsMaterial = cloudsMaterial;
+                passData.upscaleMode = upscaleMode;
+                passData.resolutionScale = resolutionScale;
+                passData.canCopy = cameraData.cameraTargetDescriptor.colorFormat == cloudsHandleFormat && cameraData.cameraTargetDescriptor.msaaSamples == 1 && fastCopy;
+                passData.denoiseClouds = denoiseClouds;
+                passData.dynamicAmbientProbe = dynamicAmbientProbe;
+                passData.outputDepth = outputDepth;
+
+                passData.cloudsHandles = cloudsHandles;
+                passData.cloudsColorHandle = cloudsTextureHandle;
+                passData.accumulateHandle = accumulateHandle;
+                passData.historyHandle = historyHandle;
+
+                ConfigureInput(ScriptableRenderPassInput.Depth);
+
+                // UnsafePasses don't setup the outputs using UseTextureFragment/UseTextureFragmentDepth, you should specify your writes with UseTexture instead
+                builder.UseTexture(passData.cameraColorHandle, AccessFlags.ReadWrite);
+                builder.UseTexture(passData.cameraDepthHandle, AccessFlags.Read);
+                builder.UseTexture(passData.cloudsColorHandle, AccessFlags.Write);
+                builder.UseTexture(passData.accumulateHandle, AccessFlags.Write);
+                builder.UseTexture(passData.historyHandle, AccessFlags.ReadWrite);
+
+                // Assign the ExecutePass function to the render pass delegate, which will be called by the render graph when executing the pass
+                builder.SetRenderFunc((PassData data, UnsafeGraphContext context) => ExecutePass(data, context));
+            }
+        }
+        #endregion
+    #endif
+
+        #region Shared
+        public void Dispose()
+        {
+            cloudsColorHandle?.Release();
+            cloudsDepthHandle?.Release();
+            historyHandle?.Release();
+            accumulateHandle?.Release();
+        }
+        #endregion
     }
-
-
     public class VolumetricCloudsAmbientPass : ScriptableRenderPass
     {
+        private const string profilerTag = "Volumetric Clouds Ambient Probe";
+
         private readonly Material cloudsMaterial;
-        public RTHandle probeHandle;
+        private RTHandle probeHandle;
+
+        private const string _VolumetricCloudsAmbientProbe = "_VolumetricCloudsAmbientProbe";
+        private static readonly int volumetricCloudsAmbientProbe = Shader.PropertyToID(_VolumetricCloudsAmbientProbe);
 
         // left, right, up, down, back, front
-        readonly Vector3[] cubemapDirs = new Vector3[6] { Vector3.forward, Vector3.back, Vector3.left, Vector3.right, Vector3.up, Vector3.down };
-        readonly Vector3[] cubemapUps = new Vector3[6] { Vector3.down, Vector3.down, Vector3.back, Vector3.forward, Vector3.left, Vector3.left };
+        private readonly Vector3[] cubemapDirs = new Vector3[6] { Vector3.forward, Vector3.back, Vector3.left, Vector3.right, Vector3.up, Vector3.down };
+        private readonly Vector3[] cubemapUps = new Vector3[6] { Vector3.down, Vector3.down, Vector3.back, Vector3.forward, Vector3.left, Vector3.left };
+
+    #if UNITY_6000_0_OR_NEWER
+        private readonly RendererListHandle[] rendererListHandles = new RendererListHandle[6];
+        private readonly Matrix4x4[] skyViewMatrices = new Matrix4x4[6];
+    #endif
+
+        private static readonly Matrix4x4 skyProjectionMatrix = Matrix4x4.Perspective(90.0f, 1.0f, 0.1f, 10.0f);
 
         public VolumetricCloudsAmbientPass(Material material)
         {
             cloudsMaterial = material;
         }
 
-        public void Dispose()
-        {
-            probeHandle?.Release();
-        }
-
+        #region Non Render Graph Pass
         public override void OnCameraSetup(CommandBuffer cmd, ref RenderingData renderingData)
         {
             RenderTextureDescriptor desc = renderingData.cameraData.cameraTargetDescriptor;
@@ -584,21 +921,14 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
             desc.width = 16;
             desc.height = 16;
             desc.dimension = TextureDimension.Cube;
-            RenderingUtils.ReAllocateIfNeeded(ref probeHandle, desc, FilterMode.Trilinear, TextureWrapMode.Clamp, name: "_VolumetricCloudsAmbientProbe");
-            cloudsMaterial.SetTexture("_VolumetricCloudsAmbientProbe", probeHandle);
+        #if UNITY_6000_0_OR_NEWER
+            RenderingUtils.ReAllocateHandleIfNeeded(ref probeHandle, desc, FilterMode.Trilinear, TextureWrapMode.Clamp, name: _VolumetricCloudsAmbientProbe);
+        #else
+            RenderingUtils.ReAllocateIfNeeded(ref probeHandle, desc, FilterMode.Trilinear, TextureWrapMode.Clamp, name: _VolumetricCloudsAmbientProbe);
+        #endif
+            cloudsMaterial.SetTexture(volumetricCloudsAmbientProbe, probeHandle);
 
             ConfigureTarget(probeHandle, probeHandle);
-        }
-
-        public override void FrameCleanup(CommandBuffer cmd)
-        {
-            if (probeHandle != null)
-                cmd.ReleaseTemporaryRT(Shader.PropertyToID(probeHandle.name));
-        }
-
-        public override void OnCameraCleanup(CommandBuffer cmd)
-        {
-            probeHandle = null;
         }
 
         public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
@@ -608,7 +938,7 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
 
             Camera camera = renderingData.cameraData.camera;
             CommandBuffer cmd = CommandBufferPool.Get();
-            using (new ProfilingScope(cmd, new ProfilingSampler("Volumetric Clouds Ambient Probe")))
+            using (new ProfilingScope(cmd, new ProfilingSampler(profilerTag)))
             {
                 for (int i = 0; i < 6; i++)
                 {
@@ -616,15 +946,14 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
 
                     Matrix4x4 viewMatrix = Matrix4x4.TRS(Vector3.zero, Quaternion.LookRotation(cubemapDirs[i], cubemapUps[i]), Vector3.one);
                     if (i == 3) { viewMatrix *= Matrix4x4.Rotate(Quaternion.Euler(Vector3.down * 180.0f)); }
-                    if (i == 4) { viewMatrix *= Matrix4x4.Rotate(Quaternion.Euler(Vector3.left * 90.0f));  }
-                    if (i == 5) { viewMatrix *= Matrix4x4.Rotate(Quaternion.Euler(Vector3.right * 90.0f)); }
+                    else if (i == 4) { viewMatrix *= Matrix4x4.Rotate(Quaternion.Euler(Vector3.left * 90.0f));  }
+                    else if (i == 5) { viewMatrix *= Matrix4x4.Rotate(Quaternion.Euler(Vector3.right * 90.0f)); }
 
                     // Set the Near & Far Plane to 0.1 and 10
-                    Matrix4x4 projectionMatrix = Matrix4x4.Perspective(90.0f, 1.0f, 0.1f, 10.0f);
-                    cmd.SetViewProjectionMatrices(viewMatrix, projectionMatrix);
+                    cmd.SetViewProjectionMatrices(viewMatrix, skyProjectionMatrix);
 
                     // Can we exclude the sun disk in ambient probe?
-                    RendererList rendererList = context.CreateSkyboxRendererList(camera, projectionMatrix, viewMatrix);
+                    RendererList rendererList = context.CreateSkyboxRendererList(camera, skyProjectionMatrix, viewMatrix);
                     cmd.DrawRendererList(rendererList);
                 }
             }
@@ -634,5 +963,564 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
             
             CommandBufferPool.Release(cmd);
         }
+        #endregion
+
+    #if UNITY_6000_0_OR_NEWER
+        #region Render Graph Pass
+        private class PassData
+        {
+            internal Material cloudsMaterial;
+
+            internal TextureHandle probeHandle;
+
+            internal Matrix4x4 worldToCameraMatrix;
+            internal Matrix4x4 projectionMatrix;
+
+            internal RendererListHandle[] rendererListHandles;
+            internal Matrix4x4[] skyViewMatrices;
+            internal Matrix4x4 skyProjectionMatrix;
+        }
+
+        // This static method is used to execute the pass and passed as the RenderFunc delegate to the RenderGraph render pass
+        static void ExecutePass(PassData data, UnsafeGraphContext context)
+        {
+            CommandBuffer cmd = CommandBufferHelpers.GetNativeCommandBuffer(context.cmd);
+
+            for (int i = 0; i < 6; i++)
+            {
+                CoreUtils.SetRenderTarget(cmd, data.probeHandle, ClearFlag.None, 0, (CubemapFace)i);
+
+                context.cmd.SetViewProjectionMatrices(data.skyViewMatrices[i], data.skyProjectionMatrix);
+
+                context.cmd.DrawRendererList(data.rendererListHandles[i]);
+            }
+
+            data.cloudsMaterial.SetTexture(volumetricCloudsAmbientProbe, data.probeHandle);
+
+            context.cmd.SetViewProjectionMatrices(data.worldToCameraMatrix, data.projectionMatrix);
+        }
+
+        // This is where the renderGraph handle can be accessed.
+        // Each ScriptableRenderPass can use the RenderGraph handle to add multiple render passes to the render graph
+        public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
+        {
+            // add an unsafe render pass to the render graph, specifying the name and the data type that will be passed to the ExecutePass function
+            using (var builder = renderGraph.AddUnsafePass<PassData>(profilerTag, out var passData))
+            {
+                // UniversalResourceData contains all the texture handles used by the renderer, including the active color and depth textures
+                // The active color and depth textures are the main color and depth buffers that the camera renders into
+                UniversalRenderingData universalRenderingData = frameData.Get<UniversalRenderingData>();
+                UniversalResourceData resourceData = frameData.Get<UniversalResourceData>();
+                UniversalCameraData cameraData = frameData.Get<UniversalCameraData>();
+
+                RenderTextureDescriptor desc = cameraData.cameraTargetDescriptor;
+                desc.depthBufferBits = 0;
+                desc.msaaSamples = 1;
+                desc.useMipMap = true;
+                desc.autoGenerateMips = true;
+                desc.width = 16;
+                desc.height = 16;
+                desc.dimension = TextureDimension.Cube;
+                RenderingUtils.ReAllocateHandleIfNeeded(ref probeHandle, desc, FilterMode.Trilinear, TextureWrapMode.Clamp, name: _VolumetricCloudsAmbientProbe);
+                TextureHandle probeTextureHandle = renderGraph.ImportTexture(probeHandle);
+                passData.probeHandle = probeTextureHandle;
+                passData.cloudsMaterial = cloudsMaterial;
+
+                // Set the Near & Far Plane to 0.1 and 10
+                for (int i = 0; i < 6; i++)
+                {
+                    Matrix4x4 viewMatrix = Matrix4x4.TRS(Vector3.zero, Quaternion.LookRotation(cubemapDirs[i], cubemapUps[i]), Vector3.one);
+                    if (i == 3) { viewMatrix *= Matrix4x4.Rotate(Quaternion.Euler(Vector3.down * 180.0f)); }
+                    else if (i == 4) { viewMatrix *= Matrix4x4.Rotate(Quaternion.Euler(Vector3.left * 90.0f)); }
+                    else if (i == 5) { viewMatrix *= Matrix4x4.Rotate(Quaternion.Euler(Vector3.right * 90.0f)); }
+
+                    skyViewMatrices[i] = viewMatrix;
+                    rendererListHandles[i] = renderGraph.CreateSkyboxRendererList(cameraData.camera, skyProjectionMatrix, viewMatrix);
+                    builder.UseRendererList(rendererListHandles[i]);
+                }
+
+                // Fill up the passData with the data needed by the pass
+                passData.rendererListHandles = rendererListHandles;
+                passData.skyViewMatrices = skyViewMatrices;
+                passData.skyProjectionMatrix = skyProjectionMatrix;
+                passData.cloudsMaterial = cloudsMaterial;
+                passData.worldToCameraMatrix = cameraData.camera.worldToCameraMatrix;
+                passData.projectionMatrix = cameraData.camera.projectionMatrix;
+
+                // UnsafePasses don't setup the outputs using UseTextureFragment/UseTextureFragmentDepth, you should specify your writes with UseTexture instead
+                builder.UseTexture(passData.probeHandle, AccessFlags.Write);
+
+                // Disable pass culling because the ambient probe is not used by other pass
+                builder.AllowPassCulling(false);
+
+                // Assign the ExecutePass function to the render pass delegate, which will be called by the render graph when executing the pass
+                builder.SetRenderFunc((PassData data, UnsafeGraphContext context) => ExecutePass(data, context));
+            }
+        }
+        #endregion
+    #endif
+
+        #region Shared
+        public void Dispose()
+        {
+            probeHandle?.Release();
+        }
+        #endregion
+    }
+    public class VolumetricCloudsShadowsPass : ScriptableRenderPass
+    {
+        private const string profilerTag = "Volumetric Clouds Shadows";
+
+        public VolumetricClouds cloudsVolume;
+        private readonly Material cloudsMaterial;
+
+        private RTHandle shadowTextureHandle;
+        private RTHandle intermediateShadowTextureHandle;
+
+        private readonly Vector3[] frustumCorners = new Vector3[4];
+
+        private Light targetLight;
+
+        private static readonly int shadowCookieResolution = Shader.PropertyToID("_ShadowCookieResolution");
+        private static readonly int shadowIntensity = Shader.PropertyToID("_ShadowIntensity");
+        private static readonly int shadowOpacityFallback = Shader.PropertyToID("_ShadowOpacityFallback");
+        private static readonly int cloudShadowSunOrigin = Shader.PropertyToID("_CloudShadowSunOrigin");
+        private static readonly int cloudShadowSunRight = Shader.PropertyToID("_CloudShadowSunRight");
+        private static readonly int cloudShadowSunUp = Shader.PropertyToID("_CloudShadowSunUp");
+        private static readonly int cloudShadowSunForward = Shader.PropertyToID("_CloudShadowSunForward");
+        private static readonly int cameraPositionPS = Shader.PropertyToID("_CameraPositionPS");
+        private static readonly int volumetricCloudsShadowOriginToggle = Shader.PropertyToID("_VolumetricCloudsShadowOriginToggle");
+        //private static readonly int shadowPlaneOffset = Shader.PropertyToID("_ShadowPlaneOffset");
+
+        private const string _VolumetricCloudsShadowTexture = "_VolumetricCloudsShadowTexture";
+        private const string _VolumetricCloudsShadowTempTexture = "_VolumetricCloudsShadowTempTexture";
+
+        private const string _LIGHT_COOKIES = "_LIGHT_COOKIES";
+
+        private static readonly Matrix4x4 s_DirLightProj = Matrix4x4.Ortho(-0.5f, 0.5f, -0.5f, 0.5f, -0.5f, 0.5f);
+
+        private static readonly int mainLightTexture = Shader.PropertyToID("_MainLightCookieTexture");
+        private static readonly int mainLightWorldToLight = Shader.PropertyToID("_MainLightWorldToLight");
+        private static readonly int mainLightCookieTextureFormat = Shader.PropertyToID("_MainLightCookieTextureFormat");
+
+        public VolumetricCloudsShadowsPass(Material material)
+        {
+            cloudsMaterial = material;
+        }
+
+        #region Non Render Graph Pass
+        private Light GetMainLight(LightData lightData)
+        {
+            int shadowLightIndex = lightData.mainLightIndex;
+            if (shadowLightIndex != -1)
+            {
+                VisibleLight shadowLight = lightData.visibleLights[shadowLightIndex];
+                Light light = shadowLight.light;
+                if (light.shadows != LightShadows.None && shadowLight.lightType == LightType.Directional)
+                    return light;
+            }
+
+            return RenderSettings.sun;
+        }
+
+        public override void OnCameraSetup(CommandBuffer cmd, ref RenderingData renderingData)
+        {
+            // Should we support colored shadows?
+            GraphicsFormat cookieFormat = GraphicsFormat.R16_UNorm; //option 2: R8_UNorm
+        #if UNITY_2023_2_OR_NEWER
+            bool useSingleChannel = SystemInfo.IsFormatSupported(cookieFormat, GraphicsFormatUsage.Render);
+        #else
+            bool useSingleChannel = SystemInfo.IsFormatSupported(cookieFormat, FormatUsage.Render);
+        #endif
+            cookieFormat = useSingleChannel ? cookieFormat : GraphicsFormat.B10G11R11_UFloatPack32;
+
+            int shadowResolution = (int)cloudsVolume.shadowResolution.value;
+            RenderTextureDescriptor desc = renderingData.cameraData.cameraTargetDescriptor;
+            desc.msaaSamples = 1;
+            desc.depthBufferBits = 0;
+            desc.useMipMap = false;
+            desc.graphicsFormat = cookieFormat;
+            desc.height = shadowResolution;
+            desc.width = shadowResolution;
+            
+        #if UNITY_6000_0_OR_NEWER
+            RenderingUtils.ReAllocateHandleIfNeeded(ref shadowTextureHandle, desc, FilterMode.Bilinear, TextureWrapMode.Clamp, name: _VolumetricCloudsShadowTexture);
+        #else
+            RenderingUtils.ReAllocateIfNeeded(ref shadowTextureHandle, desc, FilterMode.Bilinear, TextureWrapMode.Clamp, name: _VolumetricCloudsShadowTexture);
+        #endif
+
+        #if UNITY_6000_0_OR_NEWER
+            RenderingUtils.ReAllocateHandleIfNeeded(ref intermediateShadowTextureHandle, desc, FilterMode.Bilinear, TextureWrapMode.Clamp, name: _VolumetricCloudsShadowTempTexture);
+        #else
+            RenderingUtils.ReAllocateIfNeeded(ref intermediateShadowTextureHandle, desc, FilterMode.Bilinear, TextureWrapMode.Clamp, name: _VolumetricCloudsShadowTempTexture);
+        #endif
+
+            ConfigureTarget(shadowTextureHandle, shadowTextureHandle);
+        }
+
+        public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
+        {
+            CameraData cameraData = renderingData.cameraData;
+            Camera camera = cameraData.camera;
+            LightData lightData = renderingData.lightData;
+
+            // Get and update the main light
+            Light light = GetMainLight(lightData);
+            if (targetLight != light)
+            {
+                ResetShadowCookie();
+                targetLight = light;
+            }
+
+            // Check if we need shadow cookie
+            bool hasVolumetricCloudsShadows = targetLight != null && targetLight.isActiveAndEnabled && targetLight.intensity != 0.0f;
+            if (!hasVolumetricCloudsShadows)
+            {
+                ResetShadowCookie();
+                return;
+            }
+
+            CommandBuffer cmd = CommandBufferPool.Get();
+            using (new ProfilingScope(cmd, new ProfilingSampler(profilerTag)))
+            {
+                Matrix4x4 wsToLSMat = targetLight.transform.worldToLocalMatrix;
+                Matrix4x4 lsToWSMat = targetLight.transform.localToWorldMatrix;
+
+                float3 cameraPos = camera.transform.position;
+
+                float shadowDistance = cloudsVolume.shadowDistance.value;
+
+                camera.CalculateFrustumCorners(new Rect(0, 0, 1, 1), camera.farClipPlane, Camera.MonoOrStereoscopicEye.Mono, frustumCorners);
+
+                // Generate the light space bounds of the camera frustum
+                Bounds lightSpaceBounds = new Bounds();
+                lightSpaceBounds.SetMinMax(new Vector3(float.MaxValue, float.MaxValue, float.MaxValue), new Vector3(-float.MaxValue, -float.MaxValue, -float.MaxValue));
+                lightSpaceBounds.Encapsulate(wsToLSMat.MultiplyPoint(cameraPos));
+                for (int cornerIdx = 0; cornerIdx < 4; ++cornerIdx)
+                {
+                    Vector3 corner = frustumCorners[cornerIdx];
+                    float diag = corner.magnitude;
+                    corner = (corner / diag) * Mathf.Min(shadowDistance, diag);
+                    Vector3 posLightSpace = wsToLSMat.MultiplyPoint(new float3(corner) + cameraPos);
+                    lightSpaceBounds.Encapsulate(posLightSpace);
+
+                    posLightSpace = wsToLSMat.MultiplyPoint(new float3(-corner) + cameraPos);
+                    lightSpaceBounds.Encapsulate(posLightSpace);
+                }
+
+                // Compute the four corners we need
+                float3 c0 = lsToWSMat.MultiplyPoint(lightSpaceBounds.center + new Vector3(-lightSpaceBounds.extents.x, -lightSpaceBounds.extents.y, lightSpaceBounds.extents.z));
+                float3 c1 = lsToWSMat.MultiplyPoint(lightSpaceBounds.center + new Vector3(lightSpaceBounds.extents.x, -lightSpaceBounds.extents.y, lightSpaceBounds.extents.z));
+                float3 c2 = lsToWSMat.MultiplyPoint(lightSpaceBounds.center + new Vector3(-lightSpaceBounds.extents.x, lightSpaceBounds.extents.y, lightSpaceBounds.extents.z));
+
+                float actualEarthRad = Mathf.Lerp(1.0f, 0.025f, cloudsVolume.earthCurvature.value) * VolumetricCloudsPass.earthRad;
+                float3 planetCenterPos = float3(0.0f, -actualEarthRad, 0.0f);
+
+                float3 dirX = c1 - c0;
+                float3 dirY = c2 - c0;
+
+                // The shadow cookie size
+                float2 regionSize = float2(length(dirX), length(dirY));
+
+                int shadowResolution = (int)cloudsVolume.shadowResolution.value;
+
+                // Update material properties
+                cloudsMaterial.SetFloat(shadowCookieResolution, shadowResolution);
+                //cloudsMaterial.SetFloat(shadowPlaneOffset, cloudsVolume.shadowPlaneHeightOffset.value);
+                cloudsMaterial.SetFloat(shadowIntensity, cloudsVolume.shadowOpacity.value);
+                cloudsMaterial.SetFloat(shadowOpacityFallback, 1.0f - cloudsVolume.shadowOpacityFallback.value);
+                cloudsMaterial.SetVector(cloudShadowSunOrigin, float4(c0 - planetCenterPos, 1.0f));
+                cloudsMaterial.SetVector(cloudShadowSunRight, float4(dirX, 0.0f));
+                cloudsMaterial.SetVector(cloudShadowSunUp, float4(dirY, 0.0f));
+                cloudsMaterial.SetVector(cloudShadowSunForward, float4(-targetLight.transform.forward, 0.0f));
+                cloudsMaterial.SetVector(cameraPositionPS, float4(cameraPos - planetCenterPos, 0.0f));
+                cloudsMaterial.SetVector(volumetricCloudsShadowOriginToggle, float4(c0, 0.0f));
+
+                // Apply light cookie settings
+                targetLight.cookie = null;
+                targetLight.GetComponent<UniversalAdditionalLightData>().lightCookieSize = Vector2.one;
+                targetLight.GetComponent<UniversalAdditionalLightData>().lightCookieOffset = Vector2.zero;   
+
+                Vector2 uvScale = 1 / regionSize;
+                float minHalfValue = Unity.Mathematics.half.MinValue;
+                if (Mathf.Abs(uvScale.x) < minHalfValue)
+                    uvScale.x = Mathf.Sign(uvScale.x) * minHalfValue;
+                if (Mathf.Abs(uvScale.y) < minHalfValue)
+                    uvScale.y = Mathf.Sign(uvScale.y) * minHalfValue;
+
+                Matrix4x4 cookieUVTransform = Matrix4x4.Scale(new Vector3(uvScale.x, uvScale.y, 1));
+                lsToWSMat.SetColumn(3, float4(cameraPos, 1));
+                Matrix4x4 cookieMatrix = s_DirLightProj * cookieUVTransform * lsToWSMat.inverse;
+
+                float cookieFormat = (float)GetLightCookieShaderFormat(shadowTextureHandle.rt.graphicsFormat);
+
+                cmd.SetGlobalTexture(mainLightTexture, shadowTextureHandle);
+                cmd.SetGlobalMatrix(mainLightWorldToLight, cookieMatrix);
+                cmd.SetGlobalFloat(mainLightCookieTextureFormat, cookieFormat);
+                cmd.EnableShaderKeyword(_LIGHT_COOKIES);
+
+                // Render shadow cookie texture
+                Blitter.BlitCameraTexture(cmd, shadowTextureHandle, shadowTextureHandle, cloudsMaterial, pass: 4);
+
+                // Given the low number of steps available and the absence of noise in the integration, we try to reduce the artifacts by doing two consecutive 3x3 blur passes.
+                Blitter.BlitCameraTexture(cmd, shadowTextureHandle, intermediateShadowTextureHandle, cloudsMaterial, pass: 5);
+                Blitter.BlitCameraTexture(cmd, intermediateShadowTextureHandle, shadowTextureHandle, cloudsMaterial, pass: 5);
+            }
+            context.ExecuteCommandBuffer(cmd);
+            cmd.Clear();
+            CommandBufferPool.Release(cmd);
+        }
+        #endregion
+
+    #if UNITY_6000_0_OR_NEWER
+        #region Render Graph Pass
+        private Light GetMainLight(UniversalLightData lightData)
+        {
+            int shadowLightIndex = lightData.mainLightIndex;
+            if (shadowLightIndex != -1)
+            {
+                VisibleLight shadowLight = lightData.visibleLights[shadowLightIndex];
+                Light light = shadowLight.light;
+                if (light.shadows != LightShadows.None && shadowLight.lightType == LightType.Directional)
+                    return light;
+            }
+
+            return RenderSettings.sun;
+        }
+
+        private class PassData
+        {
+            internal Material cloudsMaterial;
+
+            internal TextureHandle intermediateShadowTexture;
+            internal TextureHandle shadowTexture;
+
+            internal Matrix4x4 mainLightWorldToLight;
+            internal float mainLightCookieTextureFormat;
+        }
+
+        // This static method is used to execute the pass and passed as the RenderFunc delegate to the RenderGraph render pass
+        static void ExecutePass(PassData data, UnsafeGraphContext context)
+        {
+            CommandBuffer cmd = CommandBufferHelpers.GetNativeCommandBuffer(context.cmd);
+
+            // Render shadow cookie texture
+            Blitter.BlitCameraTexture(cmd, data.shadowTexture, data.shadowTexture, data.cloudsMaterial, pass: 4);
+
+            // Given the low number of steps available and the absence of noise in the integration, we try to reduce the artifacts by doing two consecutive 3x3 blur passes.
+            Blitter.BlitCameraTexture(cmd, data.shadowTexture, data.intermediateShadowTexture, data.cloudsMaterial, pass: 5);
+            Blitter.BlitCameraTexture(cmd, data.intermediateShadowTexture, data.shadowTexture, data.cloudsMaterial, pass: 5);
+
+            cmd.SetGlobalTexture(mainLightTexture, data.shadowTexture);
+            cmd.SetGlobalMatrix(mainLightWorldToLight, data.mainLightWorldToLight);
+            cmd.SetGlobalFloat(mainLightCookieTextureFormat, data.mainLightCookieTextureFormat);
+            cmd.EnableShaderKeyword(_LIGHT_COOKIES);
+        }
+
+        // This is where the renderGraph handle can be accessed.
+        // Each ScriptableRenderPass can use the RenderGraph handle to add multiple render passes to the render graph
+        public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
+        {
+            UniversalLightData lightData = frameData.Get<UniversalLightData>();
+            UniversalRenderingData universalRenderingData = frameData.Get<UniversalRenderingData>();
+            UniversalResourceData resourceData = frameData.Get<UniversalResourceData>();
+            UniversalCameraData cameraData = frameData.Get<UniversalCameraData>();
+
+            // Get and update the main light
+            Light light = GetMainLight(lightData);
+            if (targetLight != light)
+            {
+                ResetShadowCookie();
+                targetLight = light;
+            }
+
+            // Check if we need shadow cookie
+            bool hasVolumetricCloudsShadows = targetLight != null && targetLight.isActiveAndEnabled && targetLight.intensity != 0.0f;
+            if (!hasVolumetricCloudsShadows)
+            {
+                ResetShadowCookie();
+                return;
+            }
+
+            var camera = cameraData.camera;
+
+            // add an unsafe render pass to the render graph, specifying the name and the data type that will be passed to the ExecutePass function
+            using (var builder = renderGraph.AddUnsafePass<PassData>(profilerTag, out var passData))
+            {
+                // UniversalResourceData contains all the texture handles used by the renderer, including the active color and depth textures
+                // The active color and depth textures are the main color and depth buffers that the camera renders into
+                
+                Matrix4x4 wsToLSMat = targetLight.transform.worldToLocalMatrix;
+                Matrix4x4 lsToWSMat = targetLight.transform.localToWorldMatrix;
+
+                float3 cameraPos = camera.transform.position;
+
+                float shadowDistance = cloudsVolume.shadowDistance.value;
+                
+                camera.CalculateFrustumCorners(new Rect(0, 0, 1, 1), camera.farClipPlane, Camera.MonoOrStereoscopicEye.Mono, frustumCorners);
+
+                // Generate the light space bounds of the camera frustum
+                Bounds lightSpaceBounds = new Bounds();
+                lightSpaceBounds.SetMinMax(new Vector3(float.MaxValue, float.MaxValue, float.MaxValue), new Vector3(-float.MaxValue, -float.MaxValue, -float.MaxValue));
+                lightSpaceBounds.Encapsulate(wsToLSMat.MultiplyPoint(cameraPos));
+                for (int cornerIdx = 0; cornerIdx < 4; ++cornerIdx)
+                {
+                    Vector3 corner = frustumCorners[cornerIdx];
+                    float diag = corner.magnitude;
+                    corner = (corner / diag) * Mathf.Min(shadowDistance, diag);
+                    Vector3 posLightSpace = wsToLSMat.MultiplyPoint(float3(corner) + cameraPos);
+                    lightSpaceBounds.Encapsulate(posLightSpace);
+
+                    posLightSpace = wsToLSMat.MultiplyPoint(float3(-corner) + cameraPos);
+                    lightSpaceBounds.Encapsulate(posLightSpace);
+                }
+                
+                // Compute the four corners we need
+                float3 c0 = lsToWSMat.MultiplyPoint(lightSpaceBounds.center + new Vector3(-lightSpaceBounds.extents.x, -lightSpaceBounds.extents.y, lightSpaceBounds.extents.z));
+                float3 c1 = lsToWSMat.MultiplyPoint(lightSpaceBounds.center + new Vector3(lightSpaceBounds.extents.x, -lightSpaceBounds.extents.y, lightSpaceBounds.extents.z));
+                float3 c2 = lsToWSMat.MultiplyPoint(lightSpaceBounds.center + new Vector3(-lightSpaceBounds.extents.x, lightSpaceBounds.extents.y, lightSpaceBounds.extents.z));
+
+                float actualEarthRad = Mathf.Lerp(1.0f, 0.025f, cloudsVolume.earthCurvature.value) * VolumetricCloudsPass.earthRad;
+                float3 planetCenterPos = float3(0.0f, -actualEarthRad, 0.0f);
+
+                float3 dirX = c1 - c0;
+                float3 dirY = c2 - c0;
+                 
+                // The shadow cookie size
+                float2 regionSize = float2(length(dirX), length(dirY));
+
+                // Should we support colored shadows?
+                GraphicsFormat cookieTextureFormat = GraphicsFormat.R16_UNorm; //option 2: R8_UNorm
+                bool useSingleChannel = SystemInfo.IsFormatSupported(cookieTextureFormat, GraphicsFormatUsage.Render);
+                cookieTextureFormat = useSingleChannel ? cookieTextureFormat : GraphicsFormat.B10G11R11_UFloatPack32;
+
+                int shadowResolution = (int)cloudsVolume.shadowResolution.value;
+                RenderTextureDescriptor desc = cameraData.cameraTargetDescriptor;
+                desc.msaaSamples = 1;
+                desc.depthBufferBits = 0;
+                desc.useMipMap = false;
+                desc.graphicsFormat = cookieTextureFormat;
+                desc.height = shadowResolution;
+                desc.width = shadowResolution;
+                RenderingUtils.ReAllocateHandleIfNeeded(ref shadowTextureHandle, desc, FilterMode.Bilinear, TextureWrapMode.Clamp, name: _VolumetricCloudsShadowTexture);
+                TextureHandle shadowTexture = renderGraph.ImportTexture(shadowTextureHandle);
+
+                TextureHandle intermediateShadowTexture = renderGraph.CreateTexture(new TextureDesc(shadowResolution, shadowResolution, false, false)
+                { colorFormat = cookieTextureFormat, enableRandomWrite = false, name = _VolumetricCloudsShadowTempTexture });
+                
+                // Update material properties
+                cloudsMaterial.SetFloat(shadowCookieResolution, shadowResolution);
+                //cloudsMaterial.SetFloat(shadowPlaneOffset, cloudsVolume.shadowPlaneHeightOffset.value);
+                cloudsMaterial.SetFloat(shadowIntensity, cloudsVolume.shadowOpacity.value);
+                cloudsMaterial.SetFloat(shadowOpacityFallback, 1.0f - cloudsVolume.shadowOpacityFallback.value);
+                cloudsMaterial.SetVector(cloudShadowSunOrigin, float4(c0 - planetCenterPos, 1.0f));
+                cloudsMaterial.SetVector(cloudShadowSunRight, float4(dirX, 0.0f));
+                cloudsMaterial.SetVector(cloudShadowSunUp, float4(dirY, 0.0f));
+                cloudsMaterial.SetVector(cloudShadowSunForward, float4(-targetLight.transform.forward, 0.0f));
+                cloudsMaterial.SetVector(cameraPositionPS, float4(cameraPos - planetCenterPos, 0.0f));
+                cloudsMaterial.SetVector(volumetricCloudsShadowOriginToggle, float4(c0, 0.0f));
+
+                // Apply light cookie settings
+                targetLight.cookie = null;
+                targetLight.GetComponent<UniversalAdditionalLightData>().lightCookieSize = Vector2.one;
+                targetLight.GetComponent<UniversalAdditionalLightData>().lightCookieOffset = Vector2.zero;
+
+                // Apply shadow cookie
+                Vector2 uvScale = 1 / regionSize;
+                float minHalfValue = Unity.Mathematics.half.MinValue;
+                if (Mathf.Abs(uvScale.x) < minHalfValue)
+                    uvScale.x = Mathf.Sign(uvScale.x) * minHalfValue;
+                if (Mathf.Abs(uvScale.y) < minHalfValue)
+                    uvScale.y = Mathf.Sign(uvScale.y) * minHalfValue;
+
+                Matrix4x4 cookieUVTransform = Matrix4x4.Scale(new Vector3(uvScale.x, uvScale.y, 1));
+                //cookieUVTransform.SetColumn(3, new Vector4(uvScale.x, uvScale.y, 0, 1));
+                lsToWSMat.SetColumn(3, float4(cameraPos, 1));
+                Matrix4x4 cookieMatrix = s_DirLightProj * cookieUVTransform * lsToWSMat.inverse;
+
+                float cookieFormat = (float)GetLightCookieShaderFormat(cookieTextureFormat);
+
+                // Fill up the passData with the data needed by the pass
+                passData.cloudsMaterial = cloudsMaterial;
+                passData.shadowTexture = shadowTexture;
+                passData.intermediateShadowTexture = intermediateShadowTexture;
+                passData.mainLightWorldToLight = cookieMatrix;
+                passData.mainLightCookieTextureFormat = cookieFormat;
+
+                // UnsafePasses don't setup the outputs using UseTextureFragment/UseTextureFragmentDepth, you should specify your writes with UseTexture instead
+                builder.UseTexture(passData.shadowTexture, AccessFlags.Write);
+                builder.UseTexture(passData.intermediateShadowTexture, AccessFlags.Write); // We always write to it before reading
+
+                // Shader keyword changes (_LIGHT_COOKIES) are considered as global state modifications
+                builder.AllowGlobalStateModification(true);
+                // Disable pass culling because the cookie texture is not used by other pass
+                builder.AllowPassCulling(false);
+
+                // Assign the ExecutePass function to the render pass delegate, which will be called by the render graph when executing the pass
+                builder.SetRenderFunc((PassData data, UnsafeGraphContext context) => ExecutePass(data, context));
+            }
+        }
+        #endregion
+    #endif
+
+        #region Shared
+        private enum LightCookieShaderFormat
+        {
+            None = -1,
+
+            RGB = 0,
+            Alpha = 1,
+            Red = 2
+        }
+
+        private LightCookieShaderFormat GetLightCookieShaderFormat(GraphicsFormat cookieFormat)
+        {
+            // TODO: convert this to use GraphicsFormatUtility
+            switch (cookieFormat)
+            {
+                default:
+                    return LightCookieShaderFormat.RGB;
+                // A8, A16 GraphicsFormat does not expose yet.
+                case (GraphicsFormat)54:
+                case (GraphicsFormat)55:
+                    return LightCookieShaderFormat.Alpha;
+                case GraphicsFormat.R8_SRGB:
+                case GraphicsFormat.R8_UNorm:
+                case GraphicsFormat.R8_UInt:
+                case GraphicsFormat.R8_SNorm:
+                case GraphicsFormat.R8_SInt:
+                case GraphicsFormat.R16_UNorm:
+                case GraphicsFormat.R16_UInt:
+                case GraphicsFormat.R16_SNorm:
+                case GraphicsFormat.R16_SInt:
+                case GraphicsFormat.R16_SFloat:
+                case GraphicsFormat.R32_UInt:
+                case GraphicsFormat.R32_SInt:
+                case GraphicsFormat.R32_SFloat:
+                case GraphicsFormat.R_BC4_SNorm:
+                case GraphicsFormat.R_BC4_UNorm:
+                case GraphicsFormat.R_EAC_SNorm:
+                case GraphicsFormat.R_EAC_UNorm:
+                    return LightCookieShaderFormat.Red;
+            }
+        }
+
+        private void ResetShadowCookie()
+        {
+            if (targetLight != null)
+            {
+                targetLight.cookie = null;
+                targetLight.GetComponent<UniversalAdditionalLightData>().lightCookieSize = Vector2.one;
+                targetLight.GetComponent<UniversalAdditionalLightData>().lightCookieOffset = Vector2.zero;
+            }
+        }
+
+        public void Dispose()
+        {
+            ResetShadowCookie();
+            shadowTextureHandle?.Release();
+            intermediateShadowTextureHandle?.Release();
+        }
+        #endregion
     }
 }

--- a/Assets/VolumetricClouds/VolumetricCloudsVolume.cs
+++ b/Assets/VolumetricClouds/VolumetricCloudsVolume.cs
@@ -8,6 +8,7 @@ using UnityEngine.Rendering.Universal;
 #else
 [Serializable, VolumeComponentMenuForRenderPipeline("Sky/Volumetric Clouds (URP)", typeof(UniversalRenderPipeline))]
 #endif
+[HelpURL("https://github.com/jiaozi158/UnityVolumetricCloudsURP/tree/main")]
 public class VolumetricClouds : VolumeComponent, IPostProcessComponent
 {
     /// <summary>
@@ -212,6 +213,62 @@ public class VolumetricClouds : VolumeComponent, IPostProcessComponent
     /// </summary>
     [AdditionalProperty, Tooltip("Controls the amount of multi-scattering inside the cloud.")]
     public ClampedFloatParameter multiScattering = new(0.5f, 0.0f, 1.0f);
+
+    /// <summary>
+    /// When enabled, URP evaluates the Volumetric Clouds' shadows. To render the shadows, this property overrides the cookie in the main directional light.
+    /// </summary>
+    [Header("Shadows"), Tooltip("When enabled, URP evaluates the Volumetric Clouds' shadows. To render the shadows, this property overrides the cookie in the main directional light.")]
+    public BoolParameter shadows = new BoolParameter(false);
+
+    /// <summary>
+    /// Resolution of the volumetric clouds shadow.
+    /// </summary>
+    public enum CloudShadowResolution
+    {
+        /// <summary>The volumetric clouds shadow will be 64x64.</summary>
+        VeryLow64 = 64,
+        /// <summary>The volumetric clouds shadow will be 128x128.</summary>
+        Low128 = 128,
+        /// <summary>The volumetric clouds shadow will be 256x256.</summary>
+        Medium256 = 256,
+        /// <summary>The volumetric clouds shadow will be 512x512.</summary>
+        High512 = 512,
+        /// <summary>The volumetric clouds shadow will be 1024x1024.</summary>
+        Ultra1024 = 1024,
+    }
+
+    /// <summary>
+    /// Specifies the resolution of the volumetric clouds shadow map.
+    /// </summary>
+    [Tooltip("Specifies the resolution of the volumetric clouds shadow map.")]
+    public CloudShadowResolutionParameter shadowResolution = new CloudShadowResolutionParameter(CloudShadowResolution.Medium256);
+
+    /// <summary>
+    /// Sets the size of the area covered by shadow around the camera.
+    /// </summary>
+    [Tooltip("Sets the size of the area covered by shadow around the camera.")]
+    [AdditionalProperty]
+    public MinFloatParameter shadowDistance = new MinFloatParameter(8000.0f, 1000.0f);
+
+    /// <summary>
+    /// Controls the vertical offset applied to compute the volumetric clouds shadow in meters. To have accurate results, enter the average height at which the volumetric clouds shadow is received.
+    /// </summary>
+    //[Tooltip("Controls the vertical offset applied to compute the volumetric clouds shadow in meters. To have accurate results, enter the average height at which the volumetric clouds shadow is received.")]
+    //public FloatParameter shadowPlaneHeightOffset = new FloatParameter(0.0f);
+
+    /// <summary>
+    /// Controls the opacity of the volumetric clouds shadow.
+    /// </summary>
+    [Tooltip("Controls the opacity of the volumetric clouds shadow.")]
+    [AdditionalProperty]
+    public ClampedFloatParameter shadowOpacity = new ClampedFloatParameter(1.0f, 0.0f, 1.0f);
+
+    /// <summary>
+    /// Controls the shadow opacity when outside the area covered by the volumetric clouds shadow.
+    /// </summary>
+    [Tooltip("Controls the shadow opacity when outside the area covered by the volumetric clouds shadow.")]
+    [AdditionalProperty]
+    public ClampedFloatParameter shadowOpacityFallback = new ClampedFloatParameter(0.0f, 0.0f, 1.0f);
 
     /// <summary>
     /// Temporal accumulation increases the visual quality of clouds by decreasing the noise. A higher value will give you better quality but can create ghosting.
@@ -440,10 +497,24 @@ public class VolumetricClouds : VolumeComponent, IPostProcessComponent
     public sealed class CloudFadeInParameter : VolumeParameter<CloudFadeInMode>
     {
         /// <summary>
-        /// Creates a new <see cref="CloudPresetsParameter"/> instance.
+        /// Creates a new <see cref="CloudFadeInParameter"/> instance.
         /// </summary>
         /// <param name="value">The initial value to store in the parameter.</param>
         /// <param name="overrideState">The initial override state for the parameter.</param>
         public CloudFadeInParameter(CloudFadeInMode value, bool overrideState = false) : base(value, overrideState) { }
+    }
+
+    /// <summary>
+    /// A <see cref="VolumeParameter"/> that holds a <see cref="CloudShadowResolution"/> value.
+    /// </summary>
+    [Serializable]
+    public sealed class CloudShadowResolutionParameter : VolumeParameter<CloudShadowResolution>
+    {
+        /// <summary>
+        /// Creates a new <see cref="CloudShadowResolutionParameter"/> instance.
+        /// </summary>
+        /// <param name="value">The initial value to store in the parameter.</param>
+        /// <param name="overrideState">The initial override state for the parameter.</param>
+        public CloudShadowResolutionParameter(CloudShadowResolution value, bool overrideState = false) : base(value, overrideState) { }
     }
 }

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ Reminders
 ------------
 - Some settings are still WIP, such as **Custom Cloud Map** overrides.
 - Orthographic camera is not supported.
-- Clouds shadowmap is not supported.
-- The sun lighting should be adjusted manually to support dynamic time of day since URP doesn't support physically based sky.
+- To render volumetric clouds shadows, it will override the cookie in the main directional light.
  
 License
 ------------


### PR DESCRIPTION
Added:

- [Volumetric Clouds Shadows] Added shadows for volumetric clouds, applied as shadow cookie texture in main light. (see "https://github.com/jiaozi158/UnityVolumetricCloudsURP/issues/2")

- [Render Graph Support] Supported Render Graph. (requires Unity 6000.0.0f1 or newer)

- [Lighting Improvements] Added an option to enable physically based sun attenuation for volumetric clouds. (see "https://github.com/jiaozi158/UnityVolumetricCloudsURP/issues/3")

- [Volumetric Clouds Depth] Added an option to output clouds average depth to a global texture named "_VolumetricCloudsDepthTexture". (see "https://github.com/jiaozi158/UnityVolumetricCloudsURP/issues/4")

- [Optimizations] Optimized code with reference to Torgo13's fork. Great Thanks! (see "https://github.com/Torgo13/UnityVolumetricCloudsURP")

Known Issues:

- [Volumetric Clouds Shadows] Due to URP limitations, objects above the clouds will incorrectly receive shadows.