### PR TITLE
Support the external physical-light-unit package

### DIFF
--- a/Assets/VolumetricClouds/VolumetricClouds.shader
+++ b/Assets/VolumetricClouds/VolumetricClouds.shader
@@ -561,6 +561,9 @@ Shader "Hidden/Sky/VolumetricClouds"
             float4 _BlitTexture_TexelSize;
         #endif
 
+            // "_ScreenSize" that supports dynamic resolution
+            float4 _ScreenResolution;
+
             SAMPLER(s_point_clamp_sampler);
 
         #ifndef PHYSICALLY_BASED_SKY
@@ -615,7 +618,7 @@ Shader "Hidden/Sky/VolumetricClouds"
                     float depth = cloudsColor.a == 1.0 ? UNITY_RAW_FAR_CLIP_VALUE : CLOUDS_RAW_FAR_CLIP_VALUE;
                 #endif
 
-                    PositionInputs posInput = GetPositionInput(input.positionCS.xy, _ScreenSize.zw, depth, UNITY_MATRIX_I_VP, UNITY_MATRIX_V);
+                    PositionInputs posInput = GetPositionInput(input.positionCS.xy, _ScreenResolution.zw, depth, UNITY_MATRIX_I_VP, UNITY_MATRIX_V);
 
                     half3 V = normalize(GetCameraPositionWS() - posInput.positionWS);
 
@@ -661,6 +664,9 @@ Shader "Hidden/Sky/VolumetricClouds"
             SAMPLER(s_linear_repeat_sampler);
             SAMPLER(s_trilinear_repeat_sampler);
             SAMPLER(sampler_VolumetricCloudsAmbientProbe);
+
+            // Note: This pass doesn't need to support dynamic resolution
+            //float4 _ScreenResolution;
 
             #pragma multi_compile_local_fragment _ _CLOUDS_MICRO_EROSION
             #pragma multi_compile_local_fragment _ _LOCAL_VOLUMETRIC_CLOUDS

--- a/Assets/VolumetricClouds/VolumetricCloudsURP.asmdef
+++ b/Assets/VolumetricClouds/VolumetricCloudsURP.asmdef
@@ -19,6 +19,11 @@
             "name": "com.jiaozi158.unity-physically-based-sky-urp",
             "expression": "1.0.0",
             "define": "URP_PBSKY"
+        },
+        {
+            "name": "cn.unity.physical-light-unit",
+            "expression": "0.0.1",
+            "define": "URP_PHYSICAL_LIGHT"
         }
     ],
     "noEngineReferences": false

--- a/Assets/VolumetricClouds/VolumetricCloudsURP.cs
+++ b/Assets/VolumetricClouds/VolumetricCloudsURP.cs
@@ -657,7 +657,16 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
                 bool isLinearColorSpace = QualitySettings.activeColorSpace == ColorSpace.Linear;
                 Color mainLightColor = Color.black;
                 if (mainLight != null)
-                    mainLightColor = (isLinearColorSpace ? mainLight.color.linear : mainLight.color.gamma) * (mainLight.useColorTemperature ? Mathf.CorrelatedColorTemperatureToRGB(mainLight.colorTemperature) : Color.white) * mainLight.intensity * PI;
+                    mainLightColor = (isLinearColorSpace ? mainLight.color.linear : mainLight.color.gamma) * (mainLight.useColorTemperature ? Mathf.CorrelatedColorTemperatureToRGB(mainLight.colorTemperature) : Color.white) * mainLight.intensity;
+
+            #if URP_PHYSICAL_LIGHT
+                bool isPhysicalLight = mainLight.GetComponent<AdditionalLightData>() != null;
+
+                mainLightColor = isPhysicalLight ? mainLightColor : mainLightColor * PI;
+            #else
+                mainLightColor *= PI;
+            #endif
+
                 // Pass the actual main light color to volumetric clouds shader.
                 cloudsMaterial.SetVector(sunColor, mainLightColor);
             }

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Reminders
 - Some settings are still WIP, such as **Custom Cloud Map** overrides.
 - Orthographic camera is not supported.
 - To render volumetric clouds shadows, it will override the cookie in the main directional light.
+- To customize the **planet radius and center** for volumetric clouds, install [Physically Based Sky](https://github.com/jiaozi158/UnityPhysicallyBasedSkyURP) via the package manager.
  
 License
 ------------


### PR DESCRIPTION
Added:
- Added support for "cn.unity.physical-light-unit" (external URP package).

Fixed:
- Fixed a rendering issue with physically based sky when using dynamic resolution.

Note:
This version is only compatible with Physically Based Sky v1.0.4 or higher.